### PR TITLE
Make misc improvments to GH actions

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -1,16 +1,6 @@
-name: Build pack on push to master
+name: Build pack on push to Pull Request
 on:
-  push:
-    branches:
-      - master
-    paths-ignore:
-      - ".gitignore"
-      - ".github/**"
-      - "README.md"
-      - "LICENSE"
-      - "CONTRIBUTING.md"
-      - "CODE_OF_CONDUCT.md"
-  workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +10,8 @@ jobs:
   build:
     name: Build HOGi-Labs
     runs-on: ubuntu-latest
+    env:
+      VERSION_SUFFIX: "PR-${{ github.event.number }}"
 
     steps:
       - name: Checkout Repository
@@ -27,9 +19,6 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
-
-      - name: Version Suffix
-        run: echo "VERSION_SUFFIX=NIGHTLY-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Setup Build
         uses: ./.github/actions/build_setup

--- a/.github/workflows/publish-to-github.yml
+++ b/.github/workflows/publish-to-github.yml
@@ -1,4 +1,4 @@
-name: Publish Project
+name: Publish Betas to GitHub
 
 on:
   push:

--- a/.github/workflows/spotless-check.yml
+++ b/.github/workflows/spotless-check.yml
@@ -2,6 +2,15 @@ name: Spotless Formatting Check
 
 on:
   push:
+    branches:
+      - master
+    paths-ignore:
+      - ".gitignore"
+      - ".github/**"
+      - "README.md"
+      - "LICENSE"
+      - "CONTRIBUTING.md"
+      - "CODE_OF_CONDUCT.md"
   pull_request:
 
 concurrency:


### PR DESCRIPTION
- Make it so it only runs one workflow on push to a PR, not two
- Rename the jars to make it clearer when debugging
- Ignore useless paths like README that don't need to rebuild the project on push to master